### PR TITLE
only FreeContextBuffer(result.outputBufferDesc.pBuffers) if not null

### DIFF
--- a/source/sspi/package.d
+++ b/source/sspi/package.d
@@ -247,7 +247,11 @@ struct ClientAuth
 			//auto result2 = queryContextAttributes!SecPkgInfoW(&context,SecPackageAttribute.negotiationInfo);
 		}
 
-		scope(exit) FreeContextBuffer(cast(void*)result.outputBufferDesc.pBuffers);
+		scope(exit)
+	     	{
+			if (result.outputBufferDesc.pBuffers !is null)
+				FreeContextBuffer(cast(void*)result.outputBufferDesc.pBuffers);
+		}
 		this.contextAttr = result.contextAttribute;
 		this.credentialsExpiry = result.expiry;
 		auto securityStatus = result.securityStatus;


### PR DESCRIPTION
I don't think this should do any harm; it may or may not help.  Take a look and also try and see if it helps.