### PR TITLE
version to allow leaking of buffer to prevent strange crashes in ldc optimized builds

### DIFF
--- a/source/sspi/package.d
+++ b/source/sspi/package.d
@@ -273,11 +273,12 @@ struct ClientAuth
 			//auto result2 = queryContextAttributes!SecPkgInfoW(&context,SecPackageAttribute.negotiationInfo);
 		}
 
-		scope(exit)
-		{
-			if (result.outputBufferDesc.pBuffers !is null)
-				FreeContextBuffer(cast(void*)result.outputBufferDesc.pBuffers);
-		}
+		version (SSPI_Leak) {}
+		else
+			scope (exit)
+				if (result.outputBufferDesc.pBuffers !is null)
+					FreeContextBuffer(cast(void*) result.outputBufferDesc.pBuffers);
+
 		this.contextAttr = result.contextAttribute;
 		this.credentialsExpiry = result.expiry;
 		auto securityStatus = result.securityStatus;


### PR DESCRIPTION
I've spent too long trying to work out the root cause here, so this is a workaround.